### PR TITLE
Update scope to distinctly apply at time of initial distribution

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -39,7 +39,7 @@ Version 2.0.2
 
 The present license is granted to any User of the Mod.
 
-Should the Mod be for Minecraft, as a prerequisite, the User is expected to comply with the Mojang EULA as it exists at the time the Mod is distributed.
+Should the Mod be for Minecraft, as a prerequisite, the User is expected to comply with the Mojang EULA as it exists at the time the Mod is initially distributed.
 
 This license is separate from the license of any Mod it depends on and does not invalidate any license requirement of the dependency.
 


### PR DESCRIPTION
Prevents forcing the user to accept any Mojang EULA post the mod's "release date"